### PR TITLE
Fix: Correct header handling and form processing in ApiService

### DIFF
--- a/projects/main-site/src/api/services/api.service.ts
+++ b/projects/main-site/src/api/services/api.service.ts
@@ -1,12 +1,8 @@
-// 3rd Party Library
 import fetch, { HeadersInit, Response } from 'node-fetch';
 import { AbortSignal } from 'abort-controller';
-
-// NodeJS Library
 import { URL } from 'node:url';
 
 import { Injectable } from '@nestjs/common';
-
 import { GlobalService } from './global.service';
 
 @Injectable()
@@ -15,46 +11,48 @@ export class ApiService {
   constructor(
     private gs: GlobalService
   ) {
-    //
   }
 
-  checkHeaderBody(url: URL, form: any, headers: HeadersInit): void {
-    let formBody = null;
-    if (typeof form === 'string' && !headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
-    } else if (typeof form !== 'string') {
+  checkHeaderBody(url: URL, form: string | FormData | URLSearchParams, headers: HeadersInit): void {
+    let formBody: any = null;
+
+    if (typeof form === 'string') {
+      if (headers instanceof Headers) {
+        if (!headers.has('Content-Type')) {
+          headers.set('Content-Type', 'application/json');
+        }
+      } else if (!('Content-Type' in headers)) {
+        headers['Content-Type'] = 'application/json';
+      }
+    } else if (typeof form?.entries === 'function') {
       formBody = {};
-      for (const pair of form.entries()) {
-        formBody[pair[0]] = pair[1];
+      for (const [key, value] of form.entries()) {
+        formBody[key] = value;
       }
     }
+
     this.gs.log(`[FETCH-HEADER] 🧩 ${url.toString()}`, headers);
     this.gs.log(`[FETCH-BODY] 🧩 ${url.toString()}`, formBody || form);
   }
 
-  async getData(url: URL, headers: HeadersInit, signal: AbortSignal = null): Promise<Response> {
+  async getData(url: URL, headers: HeadersInit, signal?: AbortSignal): Promise<Response> {
     this.gs.log(`[FETCH_GET-HEADER] 🧩 ${url.toString()}`, headers);
     return fetch(url.toString(), { method: 'GET', headers, signal });
   }
 
-  async postData(url: URL, form: any, headers: HeadersInit, signal: AbortSignal = null): Promise<Response> {
+  async postData(url: URL, form: string | FormData | URLSearchParams, headers: HeadersInit, signal?: AbortSignal): Promise<Response> {
     this.checkHeaderBody(url, form, headers);
     return fetch(url.toString(), { method: 'POST', body: form, headers, signal });
   }
 
-  async putData(url: URL, form: any, headers: HeadersInit, signal: AbortSignal = null): Promise<Response> {
+  async putData(url: URL, form: string | FormData | URLSearchParams, headers: HeadersInit, signal?: AbortSignal): Promise<Response> {
     this.checkHeaderBody(url, form, headers);
     return fetch(url.toString(), { method: 'PUT', body: form, headers, signal });
   }
 
-  async patchData(url: URL, form: any, headers: HeadersInit, signal: AbortSignal = null): Promise<Response> {
+  async patchData(url: URL, form: string | FormData | URLSearchParams, headers: HeadersInit, signal?: AbortSignal): Promise<Response> {
     this.checkHeaderBody(url, form, headers);
     return fetch(url.toString(), { method: 'PATCH', body: form, headers, signal });
   }
 
-  async deleteData(url: URL, headers: HeadersInit, signal: AbortSignal = null): Promise<Response> {
-    this.gs.log(`[FETCH_DELETE-HEADER] 🧩 ${url.toString()}`, headers);
-    return fetch(url.toString(), { method: 'DELETE', headers, signal });
-  }
-
-}
+  async deleteData(url: URL, he


### PR DESCRIPTION
Properly check and set 'Content-Type' header for string bodies, handling both Headers instance and plain objects.

Safely convert FormData or URLSearchParams to plain object for logging.

Updated method signatures to use precise types for form parameters.

Changed abort signal parameters to optional for better compatibility.

Improved code robustness and prevented runtime errors related to headers and form processing.